### PR TITLE
Cambio de redacción en ejercicio eliminarPropiedad

### DIFF
--- a/05-JS-IV/homework/homework.js
+++ b/05-JS-IV/homework/homework.js
@@ -31,7 +31,7 @@ function multiplicarNumeroDesconocidoPorCinco(objetoMisterioso) {
 }
 
 function eliminarPropiedad(objeto, unaPropiedad) {
-  // Elimina la propiedad "unaPropiedad" de "objeto"
+  // Elimina la propiedad de objeto cuyo nombre está pasado por el parametro unaPropiedad 
   // tip: tenes que usar bracket notation
   // Devuelve el objeto
   // Tu código:


### PR DESCRIPTION
Había confusión entre el nombre de unaPropiedad y su valor, que contiene el nombre de la propiedad a eliminar.